### PR TITLE
Upgrade to rules_docker 0.26.0 and other stuff

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export DEVELOPER_DIR=/Applications/Xcode-16.2.0.app/Contents/Developer

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@io_bazel_rules_docker//python:image.bzl", "py_image")
 load("@io_bazel_rules_docker//python3:image.bzl", "py3_image")
 load("@pip_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:packaging.bzl", "py_wheel")
@@ -38,20 +37,6 @@ compile_pip_requirements(
 
 py_binary(
     name = "main",
-    srcs = ["scraper.py"],
-    main = "scraper.py",
-    deps = [
-        requirement("requests"),
-        requirement("beautifulsoup4"),
-        requirement("lxml"),
-        requirement("aiohttp"),
-        requirement("python-daemon"),
-        "//utils:async-utils",
-    ],
-)
-
-py_image(
-    name = "test_py_image",
     srcs = ["scraper.py"],
     main = "scraper.py",
     deps = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,7 @@ http_archive(
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
+
 go_register_toolchains(version = "1.23.2")
 
 ## And on gazelle
@@ -30,9 +31,8 @@ http_archive(
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
 gazelle_dependencies()
-
-
 
 http_archive(
     name = "rules_python",
@@ -48,11 +48,9 @@ http_archive(
 #     url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.10.2.tar.gz",
 # )
 
-load("@rules_python//python:repositories.bzl", "py_repositories")
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+
 py_repositories()
-
-
-load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 python_register_toolchains(
     name = "python_3_13",
@@ -68,26 +66,25 @@ pip_parse(
 )
 
 load("@pip_deps//:requirements.bzl", "install_deps")
+
 install_deps()
 
-
 ## rules_docker
-docker_version = "0.25.0"
-
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+    sha256 = "f6dcb97e992f13bc9effd794e9bb300f06b0dadc88061f81ae68d8d5994be964",
     urls = [
-        "https://github.com/bazelbuild/rules_docker/releases/download/v{version}/rules_docker-v{version}.tar.gz".format(version = docker_version),
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_docker/releases/download/v0.26.0/rules_docker-v0.26.0.tar.gz",
+        "https://github.com/bazelbuild/rules_docker/releases/download/v0.26.0/rules_docker-v0.26.0.tar.gz",
     ],
 )
 
 load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
-load("@io_bazel_rules_docker//python:image.bzl", _py_image_repos = "repositories",)
-load("@io_bazel_rules_docker//python3:image.bzl", _py3_image_repos = "repositories",)
 
 container_repositories()
-_py_image_repos()
+
+load("@io_bazel_rules_docker//python3:image.bzl", _py3_image_repos = "repositories")
+
 _py3_image_repos()
 
 ## rules_docker ends here.


### PR DESCRIPTION
Here is a Successful Scan. https://app.staging.endorlabs.com/t/somak_test.amylraj-test/projects/6894241c066b484614344dbb/findings?versionRef=use-rules-docker-0.26.0

Also, With Tahoe 26.1 and upwards, There are some issues with the hermetic_c_toolchain so a work would be to use xcodes to 16.2 or lower. 
